### PR TITLE
Fix broken package index

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -1,20 +1,20 @@
 menu.version=Version
 
 iskra-nano-pb.name=Amperka Iskra Nano PB
-iskra-nano-pb.upload.tool=avrdudecustom
+iskra-nano-pb.upload.tool=arduino:avrdude
 iskra-nano-pb.upload.protocol=arduino
 iskra-nano-pb.upload.mcu=atmega328pb
 iskra-nano-pb.upload.maximum_size=32256
 iskra-nano-pb.upload.maximum_data_size=2048
 
-iskra-nano-pb.bootloader.tool=avrdudecustom
+iskra-nano-pb.bootloader.tool=arduino:avrdude
 iskra-nano-pb.bootloader.low_fuses=0xFF
 iskra-nano-pb.bootloader.high_fuses=0xDE
 iskra-nano-pb.bootloader.unlock_bits=0xFF
 iskra-nano-pb.bootloader.lock_bits=0xCF
 
-iskra-nano-pb.build.mcu=atmega328p
-iskra-nano-pb.build.board=AVR_A_STAR_328PB
+iskra-nano-pb.build.mcu=atmega328pb
+iskra-nano-pb.build.board=AVR_ISKRA_NANO_PB
 iskra-nano-pb.build.extra_flags=-include "{runtime.platform.path}/variants/iskra-nano-pb/io_328pb.h"
 iskra-nano-pb.build.core=arduino:arduino
 iskra-nano-pb.build.variant=iskra-nano-pb

--- a/extra_avrdude.conf
+++ b/extra_avrdude.conf
@@ -1,6 +1,0 @@
-part parent "m328p"
-    id = "m328pb";
-    desc = "ATmega328PB";
-    signature = 0x1e 0x95 0x16;
-    ocdrev = 1;
-;

--- a/package_amperka_index.json
+++ b/package_amperka_index.json
@@ -5,7 +5,6 @@
       "maintainer": "Amperka",
       "websiteURL": "http://amperka.ru/",
       "email": "sail@amperka.ru",
-
       "platforms": [
         {
           "name": "Amperka Boards",
@@ -20,12 +19,13 @@
           "checksum": "SHA-256:3c45e0277aa8fe9091cb43b53fa613441039af86fc958fe8166afcc9b2ac7581",
           "size": "53894",
           "boards": [
-            {"name": "Amperka Iskra Nano PB"}
+            {
+              "name": "Amperka Iskra Nano PB"
+            }
           ],
           "toolsDependencies": []
         }
       ],
-
       "tools": []
     }
   ]

--- a/package_amperka_index.json
+++ b/package_amperka_index.json
@@ -3,11 +3,11 @@
     {
       "name": "amperka-iskra",
       "maintainer": "Amperka",
-      "websiteURL": "http://amperka.ru/",
-      "email": "sail@amperka.ru",
+      "websiteURL": "http://amperka.com/",
+      "email": "dev@amperka.com",
       "platforms": [
         {
-          "name": "Amperka Boards",
+          "name": "Amperka AVR Boards",
           "architecture": "avr",
           "version": "0.0.1",
           "category": "Contributed",
@@ -23,7 +23,18 @@
               "name": "Amperka Iskra Nano PB"
             }
           ],
-          "toolsDependencies": []
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avr-gcc",
+              "version": "5.4.0-atmel3.6.1-arduino2"
+            },
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.3.0-arduino14"
+            }
+          ]
         }
       ],
       "tools": []

--- a/platform.txt
+++ b/platform.txt
@@ -1,25 +1,4 @@
 name=Amperka Iskra Boards
 version=0.0.1
 
-tools.avrdudecustom.path={runtime.tools.avrdude.path}
-tools.avrdudecustom.cmd.path={path}/bin/avrdude
-tools.avrdudecustom.config.path={path}/etc/avrdude.conf
-tools.avrdudecustom.config.path2={runtime.platform.path}/extra_avrdude.conf
-
-tools.avrdudecustom.upload.params.verbose=-v
-tools.avrdudecustom.upload.params.quiet=-q -q
-tools.avrdudecustom.upload.params.noverify=-V
-tools.avrdudecustom.upload.pattern="{cmd.path}" "-C{config.path}" "-C+{config.path2}" {upload.verbose} {upload.verify} -p{upload.mcu} -c{upload.protocol} "-P{serial.port}" -b{upload.speed} -D "-Uflash:w:{build.path}/{build.project_name}.hex:i"
-
-tools.avrdudecustom.erase.params.verbose=-v
-tools.avrdudecustom.erase.params.quiet=-q -q
-tools.avrdudecustom.erase.pattern="{cmd.path}" "-C{config.path}" "-C+{config.path2}" {erase.verbose} -p{upload.mcu} -c{protocol} {program.extra_params} -B 5 -e -Ulock:w:{bootloader.unlock_bits}:m -Uefuse:w:{bootloader.extended_fuses}:m -Uhfuse:w:{bootloader.high_fuses}:m -Ulfuse:w:{bootloader.low_fuses}:m
-
-tools.avrdudecustom.program.params.verbose=-v
-tools.avrdudecustom.program.params.quiet=-q -q
-tools.avrdudecustom.program.params.noverify=-V
-tools.avrdudecustom.program.pattern="{cmd.path}" "-C{config.path}" "-C+{config.path2}" {program.verbose} {program.verify} -p{upload.mcu} -c{protocol} {program.extra_params} -B 0.5 "-Uflash:w:{build.path}/{build.project_name}.hex:i"
-
-tools.avrdudecustom.bootloader.params.verbose=-v
-tools.avrdudecustom.bootloader.params.quiet=-q -q
-tools.avrdudecustom.bootloader.pattern="{cmd.path}" "-C{config.path}" "-C+{config.path2}" {bootloader.verbose} -p{upload.mcu} -c{protocol} {program.extra_params} -B 0.5 "-Uflash:w:{runtime.platform.path}/bootloaders/{bootloader.file}:i" -Ulock:w:{bootloader.lock_bits}:m
+recipe.output.tmp_file={build.project_name}.hex

--- a/programmers.txt
+++ b/programmers.txt
@@ -1,6 +1,0 @@
-stk500for328PB.name=STK500 for Pololu A-Star 328PB
-stk500for328PB.communication=serial
-stk500for328PB.protocol=stk500
-stk500for328PB.program.protocol=stk500
-stk500for328PB.program.tool=avrdudecustom
-stk500for328PB.program.extra_params=-P{serial.port}


### PR DESCRIPTION
Closes #1 

1. Fix windows-style line endings in package index (first commit)
2. Add latest `avrdude` from main Arduino's `package_index.json`

Someone with hardware, please test this on the clean installation! With Arduino IDE, and with `arduino-cli` only, when no package or tool installed.

P.S. Not so good name of `package_amperka_index.json`. It can be a conflict when Amperka creates another package (not Iskra).