### PR TITLE
Fix license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,55 +1,23 @@
-Copyright (c) 2014 Pololu Corporation.  For more information, see
+MIT License
 
-http://www.pololu.com/
-http://forum.pololu.com/
+Copyright (c) 2011 Dean Camera (dean [at] fourwalledcubicle [dot] com)
+Copyright (c) 2014 Pololu Corporation
+Copyright (c) 2019 Amperka
 
-Permission is hereby granted, free of charge, to any person
-obtaining a copy of this software and associated documentation
-files (the "Software"), to deal in the Software without
-restriction, including without limitation the rights to use,
-copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following
-conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-
-
-This additional license applies to the files in bootloaders/caterina:
-
-Copyright 2011  Dean Camera (dean [at] fourwalledcubicle [dot] com)
-
-Permission to use, copy, modify, distribute, and sell this
-software and its documentation for any purpose is hereby granted
-without fee, provided that the above copyright notice appear in
-all copies and that both that the copyright notice and this
-permission notice and warranty disclaimer appear in supporting
-documentation, and that the name of the author not be used in
-advertising or publicity pertaining to distribution of the
-software without specific, written prior permission.
-
-The author disclaim all warranties with regard to this
-software, including all implied warranties of merchantability
-and fitness.  In no event shall the author be liable for any
-special, indirect or consequential damages or any damages
-whatsoever resulting from loss of use, data or profits, whether
-in an action of contract, negligence or other tortious action,
-arising out of or in connection with the use or performance of
-this software.
-
-
-
-
-
-
-stolen by Amperka 2019
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
"stolen by Amperka" is not a license, it's a lawsuit.
Luckily, two legacy licenses are just MIT License variants, so we can just inherit it's and fold to one MIT License.